### PR TITLE
Xcode project with Framework targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: objective-c
+os: osx
+osx_image: xcode7.3
+env:
+  matrix:
+    - TEST_TYPE=iOS
+    - TEST_TYPE=CocoaPods
+    - TEST_TYPE=Carthage
+install:
+- |
+  if [ "$TEST_TYPE" = "iOS" ]; then
+    gem install xcpretty -N --no-ri --no-rdoc
+    gem update cocoapods
+  elif [ "$TEST_TYPE" = Carthage ]; then    
+    brew install carthage || brew upgrade carthage
+  fi
+script:
+- |
+  if [ "$TEST_TYPE" = "iOS" ]; then
+    set -o pipefail
+    xcodebuild build -project FXNotifications.xcodeproj -scheme FXNotifications-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 4s" | xcpretty -c
+  elif [ "$TEST_TYPE" = CocoaPods ]; then
+    pod lib lint FXNotifications.podspec.json
+    pod lib lint --use-libraries FXNotifications.podspec.json
+  elif [ "$TEST_TYPE" = Carthage ]; then
+    carthage build --no-skip-current
+  fi

--- a/FXNotifications.podspec.json
+++ b/FXNotifications.podspec.json
@@ -15,6 +15,8 @@
   "requires_arc": true,
   "platforms": {
     "ios": "5.0",
-    "osx": "10.7"
+    "osx": "10.7",
+    "tvos": "9.0",
+    "watchos": "2.0"
   }
 }

--- a/FXNotifications.xcodeproj/project.pbxproj
+++ b/FXNotifications.xcodeproj/project.pbxproj
@@ -1,0 +1,626 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4628F1521CD200B500EF0E20 /* FXNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628F1511CD200B500EF0E20 /* FXNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4628F15A1CD2011100EF0E20 /* FXNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 4628F1591CD2011100EF0E20 /* FXNotifications.m */; };
+		4628F1691CD2044900EF0E20 /* FXNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628F1511CD200B500EF0E20 /* FXNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4628F16A1CD2044D00EF0E20 /* FXNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 4628F1591CD2011100EF0E20 /* FXNotifications.m */; };
+		4628F1861CD20C2100EF0E20 /* FXNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628F1511CD200B500EF0E20 /* FXNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4628F1871CD20C2200EF0E20 /* FXNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628F1511CD200B500EF0E20 /* FXNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4628F1881CD20C2800EF0E20 /* FXNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 4628F1591CD2011100EF0E20 /* FXNotifications.m */; };
+		4628F1891CD20C2800EF0E20 /* FXNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 4628F1591CD2011100EF0E20 /* FXNotifications.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4628F14E1CD200B500EF0E20 /* FXNotifications.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXNotifications.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4628F1511CD200B500EF0E20 /* FXNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FXNotifications.h; sourceTree = "<group>"; };
+		4628F1531CD200B500EF0E20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Info.plist; sourceTree = "<group>"; };
+		4628F1591CD2011100EF0E20 /* FXNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FXNotifications.m; sourceTree = "<group>"; };
+		4628F1601CD201CF00EF0E20 /* FXNotifications.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXNotifications.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4628F1711CD2050C00EF0E20 /* FXNotifications.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXNotifications.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4628F17E1CD205CC00EF0E20 /* FXNotifications.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FXNotifications.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4628F14A1CD200B500EF0E20 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F15C1CD201CF00EF0E20 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F16D1CD2050C00EF0E20 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F17A1CD205CC00EF0E20 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4628F1441CD200B500EF0E20 = {
+			isa = PBXGroup;
+			children = (
+				4628F1501CD200B500EF0E20 /* FXNotifications */,
+				4628F14F1CD200B500EF0E20 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4628F14F1CD200B500EF0E20 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4628F14E1CD200B500EF0E20 /* FXNotifications.framework */,
+				4628F1601CD201CF00EF0E20 /* FXNotifications.framework */,
+				4628F1711CD2050C00EF0E20 /* FXNotifications.framework */,
+				4628F17E1CD205CC00EF0E20 /* FXNotifications.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4628F1501CD200B500EF0E20 /* FXNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				4628F1511CD200B500EF0E20 /* FXNotifications.h */,
+				4628F1591CD2011100EF0E20 /* FXNotifications.m */,
+				4628F1531CD200B500EF0E20 /* Info.plist */,
+			);
+			path = FXNotifications;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4628F14B1CD200B500EF0E20 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F1521CD200B500EF0E20 /* FXNotifications.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F15D1CD201CF00EF0E20 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F1691CD2044900EF0E20 /* FXNotifications.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F16E1CD2050C00EF0E20 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F1861CD20C2100EF0E20 /* FXNotifications.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F17B1CD205CC00EF0E20 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F1871CD20C2200EF0E20 /* FXNotifications.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4628F14D1CD200B500EF0E20 /* FXNotifications-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4628F1561CD200B500EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-iOS" */;
+			buildPhases = (
+				4628F1491CD200B500EF0E20 /* Sources */,
+				4628F14A1CD200B500EF0E20 /* Frameworks */,
+				4628F14B1CD200B500EF0E20 /* Headers */,
+				4628F14C1CD200B500EF0E20 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FXNotifications-iOS";
+			productName = FXNotifications;
+			productReference = 4628F14E1CD200B500EF0E20 /* FXNotifications.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4628F15F1CD201CF00EF0E20 /* FXNotifications-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4628F1651CD201CF00EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-OSX" */;
+			buildPhases = (
+				4628F15B1CD201CF00EF0E20 /* Sources */,
+				4628F15C1CD201CF00EF0E20 /* Frameworks */,
+				4628F15D1CD201CF00EF0E20 /* Headers */,
+				4628F15E1CD201CF00EF0E20 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FXNotifications-OSX";
+			productName = "FXNotifications-OSX";
+			productReference = 4628F1601CD201CF00EF0E20 /* FXNotifications.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4628F1701CD2050C00EF0E20 /* FXNotifications-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4628F1761CD2050C00EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-watchOS" */;
+			buildPhases = (
+				4628F16C1CD2050C00EF0E20 /* Sources */,
+				4628F16D1CD2050C00EF0E20 /* Frameworks */,
+				4628F16E1CD2050C00EF0E20 /* Headers */,
+				4628F16F1CD2050C00EF0E20 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FXNotifications-watchOS";
+			productName = "FXNotifications-watchOS";
+			productReference = 4628F1711CD2050C00EF0E20 /* FXNotifications.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4628F17D1CD205CC00EF0E20 /* FXNotifications-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4628F1831CD205CC00EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-tvOS" */;
+			buildPhases = (
+				4628F1791CD205CC00EF0E20 /* Sources */,
+				4628F17A1CD205CC00EF0E20 /* Frameworks */,
+				4628F17B1CD205CC00EF0E20 /* Headers */,
+				4628F17C1CD205CC00EF0E20 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FXNotifications-tvOS";
+			productName = "FXNotifications-tvOS";
+			productReference = 4628F17E1CD205CC00EF0E20 /* FXNotifications.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4628F1451CD200B500EF0E20 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = FX;
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "Nick Lockwood";
+				TargetAttributes = {
+					4628F14D1CD200B500EF0E20 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					4628F15F1CD201CF00EF0E20 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					4628F1701CD2050C00EF0E20 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					4628F17D1CD205CC00EF0E20 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 4628F1481CD200B500EF0E20 /* Build configuration list for PBXProject "FXNotifications" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4628F1441CD200B500EF0E20;
+			productRefGroup = 4628F14F1CD200B500EF0E20 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4628F14D1CD200B500EF0E20 /* FXNotifications-iOS */,
+				4628F15F1CD201CF00EF0E20 /* FXNotifications-OSX */,
+				4628F1701CD2050C00EF0E20 /* FXNotifications-watchOS */,
+				4628F17D1CD205CC00EF0E20 /* FXNotifications-tvOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4628F14C1CD200B500EF0E20 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F15E1CD201CF00EF0E20 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F16F1CD2050C00EF0E20 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F17C1CD205CC00EF0E20 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4628F1491CD200B500EF0E20 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F15A1CD2011100EF0E20 /* FXNotifications.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F15B1CD201CF00EF0E20 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F16A1CD2044D00EF0E20 /* FXNotifications.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F16C1CD2050C00EF0E20 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F1881CD20C2800EF0E20 /* FXNotifications.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4628F1791CD205CC00EF0E20 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4628F1891CD20C2800EF0E20 /* FXNotifications.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4628F1541CD200B500EF0E20 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MODULEMAP_FILE = module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				RUN_CLANG_STATIC_ANALYZER = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4628F1551CD200B500EF0E20 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MODULEMAP_FILE = module.modulemap;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				RUN_CLANG_STATIC_ANALYZER = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4628F1571CD200B500EF0E20 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		4628F1581CD200B500EF0E20 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		4628F1661CD201CF00EF0E20 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4628F1671CD201CF00EF0E20 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		4628F1771CD2050C00EF0E20 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		4628F1781CD2050C00EF0E20 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		4628F1841CD205CC00EF0E20 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		4628F1851CD205CC00EF0E20 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.charcoaldesign.FXNotifications;
+				PRODUCT_NAME = FXNotifications;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4628F1481CD200B500EF0E20 /* Build configuration list for PBXProject "FXNotifications" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4628F1541CD200B500EF0E20 /* Debug */,
+				4628F1551CD200B500EF0E20 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4628F1561CD200B500EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4628F1571CD200B500EF0E20 /* Debug */,
+				4628F1581CD200B500EF0E20 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4628F1651CD201CF00EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4628F1661CD201CF00EF0E20 /* Debug */,
+				4628F1671CD201CF00EF0E20 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		4628F1761CD2050C00EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4628F1771CD2050C00EF0E20 /* Debug */,
+				4628F1781CD2050C00EF0E20 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		4628F1831CD205CC00EF0E20 /* Build configuration list for PBXNativeTarget "FXNotifications-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4628F1841CD205CC00EF0E20 /* Debug */,
+				4628F1851CD205CC00EF0E20 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4628F1451CD200B500EF0E20 /* Project object */;
+}

--- a/FXNotifications.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/FXNotifications.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:FXNotifications.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-OSX.xcscheme
+++ b/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-OSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4628F15F1CD201CF00EF0E20"
+               BuildableName = "FXNotifications.framework"
+               BlueprintName = "FXNotifications-OSX"
+               ReferencedContainer = "container:FXNotifications.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F15F1CD201CF00EF0E20"
+            BuildableName = "FXNotifications.framework"
+            BlueprintName = "FXNotifications-OSX"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F15F1CD201CF00EF0E20"
+            BuildableName = "FXNotifications.framework"
+            BlueprintName = "FXNotifications-OSX"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-iOS.xcscheme
+++ b/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4628F14D1CD200B500EF0E20"
+               BuildableName = "FXNotifications.framework"
+               BlueprintName = "FXNotifications-iOS"
+               ReferencedContainer = "container:FXNotifications.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F14D1CD200B500EF0E20"
+            BuildableName = "FXNotifications.framework"
+            BlueprintName = "FXNotifications-iOS"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F14D1CD200B500EF0E20"
+            BuildableName = "FXNotifications.framework"
+            BlueprintName = "FXNotifications-iOS"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-tvOS.xcscheme
+++ b/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4628F17D1CD205CC00EF0E20"
+               BuildableName = "FXNotifications-tvOS.framework"
+               BlueprintName = "FXNotifications-tvOS"
+               ReferencedContainer = "container:FXNotifications.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F17D1CD205CC00EF0E20"
+            BuildableName = "FXNotifications-tvOS.framework"
+            BlueprintName = "FXNotifications-tvOS"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F17D1CD205CC00EF0E20"
+            BuildableName = "FXNotifications-tvOS.framework"
+            BlueprintName = "FXNotifications-tvOS"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-watchOS.xcscheme
+++ b/FXNotifications.xcodeproj/xcshareddata/xcschemes/FXNotifications-watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4628F1701CD2050C00EF0E20"
+               BuildableName = "FXNotifications.framework"
+               BlueprintName = "FXNotifications-watchOS"
+               ReferencedContainer = "container:FXNotifications.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F1701CD2050C00EF0E20"
+            BuildableName = "FXNotifications.framework"
+            BlueprintName = "FXNotifications-watchOS"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4628F1701CD2050C00EF0E20"
+            BuildableName = "FXNotifications.framework"
+            BlueprintName = "FXNotifications-watchOS"
+            ReferencedContainer = "container:FXNotifications.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.1.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2013 Nick Lockwood. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,0 +1,3 @@
+framework module FXNotifications {
+  header "FXNotifications.h"
+}


### PR DESCRIPTION
Added an Xcode project for building dynamic frameworks for OSX, iOS, tvOS, and watchOS. I tried to keep the project as simple as possible, it only uses one `Info.plist` and uses a modulemap over an umbrella header.
Carthage can build this project.

I have also updated the podspec to include tvOS and watchOS.

Included is a `.travis.yml` for running CI on travis. CI will validate the Xcode project builds, lint the podspec, and build binaries with carthage.
See the results here for my fork, you will need to enable travis builds for this repository yourself.
https://travis-ci.org/Ashton-W/FXNotifications

You could add [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) to the `README.md` too if you want 

```
[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
```
